### PR TITLE
Use relative paths if possible

### DIFF
--- a/zk
+++ b/zk
@@ -12,6 +12,10 @@ if [ ! -d "$ZKPATH" ]; then
     exit 1
 fi
 
+if [ -x "$(command -v realpath)" ]; then
+  ZKPATH=$(realpath --relative-to="$PWD" "$ZKPATH")
+fi
+
 usage(){
     echo "Usage: $app <subcommand> [options]"
     echo ""


### PR DESCRIPTION
`rg`, `ag`, `grep` and friends display relative paths by default which is nice. Using `$ZKPATH` with these tools in the way we do results in absolute paths, which can get noisy:

```
~/Dropbox/notes 
❯ zk s test
/Users/wynn/Dropbox/notes/20200329194405-another-test.md
/Users/wynn/Dropbox/notes/20200329185349-an-test-note.md
```

This change uses [realpath](http://man7.org/linux/man-pages/man1/realpath.1.html) to pass a relative path based on the current working directory and the configured `ZKPATH`.

```
~/Dropbox/notes
❯ zk s test
20200329185349-an-test-note.md
20200329194405-another test.md
```

or if you're not in your ZK folder it looks like:

```
~/code/zk relative-paths*
❯ zk s test
../../Dropbox/notes/20200329194405-another test.md
../../Dropbox/notes/20200329185349-an-test-note.md
```